### PR TITLE
feat: Add `format` option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,13 +50,12 @@ _Note_: Does not support class components.
 
 ### Options
 
-#### attributes
+#### `attributes`
 
 By default attributes with name `data-testid` will be added. You can also define custom attribute names via plugin options in your babel config.
 
-.babelrc.json
-
 ```json
+// .babelrc.json
 {
   "plugins": [["react-data-testid", { "attributes": ["data-cy"] }]]
 }
@@ -88,6 +87,27 @@ If you need to add multiple attributes, you can define an attributes array as fo
     ["react-data-testid", { "attributes": ["data-testid", "data-cy"] }]
   ]
 }
+```
+
+#### `format`
+
+You can change how the component name is formatted using `format` option.
+
+```json
+// .babelrc.json
+{
+  "plugins": [["react-data-testid", { "option": ["My%s"] }]]
+}
+```
+
+```js
+const Hello = () => <div>hello</div>
+```
+
+After:
+
+```js
+const Hello = () => <div data-testid="MyHello">hello</div>
 ```
 
 ## Contributors ✨

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -194,3 +194,36 @@ const Div = () => <div data-cy="hello" data-testid="Div" />
 
 
 `;
+
+exports[`with format function Component: function Component 1`] = `
+
+function Div() {
+  return <div />
+}
+
+function Nested() {
+  return (
+    <div>
+      hello
+      <div>world</div>
+    </div>
+  )
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+function Div() {
+  return <div data-testid="_Div" />
+}
+
+function Nested() {
+  return (
+    <div data-testid="_Nested">
+      hello
+      <div>world</div>
+    </div>
+  )
+}
+
+
+`;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -104,3 +104,14 @@ const Div = () => <div data-cy="hello" />
     },
   ],
 })
+
+pluginTester({
+  title: 'with format',
+  plugin,
+  pluginOptions: {
+    format: '_%s',
+  },
+  babelOptions: { parserOpts: { plugins: ['jsx'] } },
+  snapshot: true,
+  tests: [test1],
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ const functionVisitor: Visitor<VisitorState> = {
 type State = {
   opts: {
     attributes?: string[]
+    format?: string
   }
 }
 
@@ -92,14 +93,19 @@ export default function plugin(): PluginObj<State> {
         }
 
         const attributes = state.opts.attributes ?? [DEFAULT_DATA_TESTID]
+        const format = state.opts.format ?? '%s'
+        const formattedName = format.replace('%s', identifier.name)
 
         if (path.isArrowFunctionExpression()) {
           path.traverse(returnStatementVistor, {
-            name: identifier.name,
+            name: formattedName,
             attributes,
           })
         } else {
-          path.traverse(functionVisitor, { name: identifier.name, attributes })
+          path.traverse(functionVisitor, {
+            name: formattedName,
+            attributes,
+          })
         }
       },
     },


### PR DESCRIPTION
**What**:

Adds `format: string` option that can be used like this: `format: "Prefix%sSuffix"`, to make the id look `PreffixHelloSuffix` instead of `Hello` if your component is named as `Hello`.

**Why**:

I think there might be many cases, but our case was this: we already have a lot of test ids defined manually, and now adding this plugin would make the automatic and manual test ids mix with each other, which would break our existing e2e tests (thus, making the migration to this plugin much more difficult).

After we change the automatic IDs to be named like `_%s`, then things will get much easier ;)

**Checklist**:

* [x] Documentation
* [x] Tests
* [x] Ready to be merged