### PR TITLE
fix: Add the props as the first attributes, not the last ones, so that they can be replaced manually if desired

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -112,7 +112,7 @@ const Div = (props) => {
 
 const Div = (props) => {
   return (
-    <div {...props} data-testid="Div">
+    <div data-testid="Div" {...props}>
       hello
     </div>
   )
@@ -190,7 +190,7 @@ const Div = () => <div data-cy="hello" />
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-const Div = () => <div data-cy="hello" data-testid="Div" />
+const Div = () => <div data-testid="Div" data-cy="hello" />
 
 
 `;

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ const returnStatementVistor: Visitor<VisitorState> = {
       if (!hasDataAttribute(openingElement.node, attribute)) {
         const dataAttribute = createDataAttribute(name, attribute)
         // @ts-ignore
-        openingElement.node.attributes.push(dataAttribute)
+        openingElement.node.attributes.unshift(dataAttribute)
       }
     }
   },
@@ -90,8 +90,9 @@ export default function plugin(): PluginObj<State> {
         if (!identifier) {
           return
         }
-
-        const attributes = state.opts.attributes ?? [DEFAULT_DATA_TESTID]
+        const attributes = [
+          ...(state.opts.attributes ?? [DEFAULT_DATA_TESTID]),
+        ].reverse()
 
         if (path.isArrowFunctionExpression()) {
           path.traverse(returnStatementVistor, {


### PR DESCRIPTION
Currently the testid prop is added at the end of all props. Which IMHO isn't nice, because it doesn't let the developer intentionally set their own testid if they want to.

For example, if they have a component

```ts
const Button = ({ testID }) => (
  <div data-testid={testID} />
)
```

Then if you do `<Button testID="SubmitButton" />` it will still have the `Button` testid, not the `SubmitButton`.

**Checklist**:

* [ ] Documentation
* [x] Tests
* [x] Ready to be merged